### PR TITLE
Add Docker build platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ steps:
 | buildArgs    | Docker build arguments passed via `--build-arg`                                                          | No       | List    |
 | labels       | Docker build labels passed via `--label`                                                                 | No       | List    |
 | target       | Docker build target passed via `--target`                                                                | No       | String  |
+| platform     | Docker build target passed via `--platform`                                                              | No       | String  |
 | username     | Docker registry username                                                                                 | No       | String  |
 | password     | Docker registry password or token                                                                        | No       | String  |
 | githubOrg    | GitHub organization to push image to (if not current)                                                    | No       | String  |

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
   target:
     description: "Docker build target passed via --target"
     required: false
+  platform:
+    description: "Docker platform passed via --platform"
+    required: false
   username:
     description: "Docker registry username"
     required: false

--- a/src/docker-build-push.js
+++ b/src/docker-build-push.js
@@ -11,6 +11,7 @@ let buildArgs;
 let githubOwner;
 let labels;
 let target;
+let platform;
 
 // Convert buildArgs from String to Array, as GH Actions currently does not support Arrays
 const processBuildArgsInput = buildArgsInput => {
@@ -35,6 +36,7 @@ const processInputs = () => {
   githubOwner = core.getInput('githubOrg') || github.getDefaultOwner();
   labels = split(core.getInput('labels'));
   target = core.getInput('target');
+  platform = core.getInput('platform');
 };
 
 const isGithubRegistry = () => GITHUB_REGISTRY_URLS.includes(registry);
@@ -58,7 +60,7 @@ const run = () => {
     core.info(`Docker image name created: ${imageFullName}`);
 
     docker.login();
-    docker.build(imageFullName, tags, buildArgs, labels, target);
+    docker.build(imageFullName, tags, buildArgs, labels, target, platform);
     docker.push(imageFullName, tags);
 
     core.setOutput('imageFullName', imageFullName);

--- a/src/docker.js
+++ b/src/docker.js
@@ -49,7 +49,7 @@ const createTags = () => {
   return dockerTags;
 };
 
-const createBuildCommand = (dockerfile, imageName, tags, buildDir, buildArgs, labels, target) => {
+const createBuildCommand = (dockerfile, imageName, tags, buildDir, buildArgs, labels, target, platform) => {
   const tagsSuffix = tags.map(tag => `-t ${imageName}:${tag}`).join(' ');
   let buildCommandPrefix = `docker build -f ${dockerfile} ${tagsSuffix}`;
 
@@ -68,10 +68,15 @@ const createBuildCommand = (dockerfile, imageName, tags, buildDir, buildArgs, la
     buildCommandPrefix = `${buildCommandPrefix} ${targetSuffix}`;
   }
 
+  if (platform) {
+    const platformSuffix = `--platform ${platform}`;
+    buildCommandPrefix = `${buildCommandPrefix} ${platformSuffix}`;
+  }
+
   return `${buildCommandPrefix} ${buildDir}`;
 };
 
-const build = (imageName, tags, buildArgs, labels, target) => {
+const build = (imageName, tags, buildArgs, labels, target, platform) => {
   const dockerfile = core.getInput('dockerfile');
   const buildDir = core.getInput('directory') || '.';
 
@@ -80,7 +85,10 @@ const build = (imageName, tags, buildArgs, labels, target) => {
   }
 
   core.info(`Building Docker image ${imageName} with tags ${tags}...`);
-  cp.execSync(createBuildCommand(dockerfile, imageName, tags, buildDir, buildArgs, labels, target), cpOptions);
+  cp.execSync(
+    createBuildCommand(dockerfile, imageName, tags, buildDir, buildArgs, labels, target, platform),
+    cpOptions
+  );
 };
 
 const isEcr = registry => registry && registry.includes('amazonaws');

--- a/tests/docker.test.js
+++ b/tests/docker.test.js
@@ -218,6 +218,22 @@ describe('core and cp methods', () => {
       );
     });
 
+    test('Build with platform', () => {
+      core.getInput.mockReturnValueOnce('Dockerfile');
+      core.getInput.mockReturnValueOnce('.');
+      fs.existsSync.mockReturnValueOnce(true);
+      const image = 'docker.io/this-project/that-image';
+      const tag = 'latest';
+      const platform = 'linux/amd64,linux/arm64';
+
+      docker.build(image, [tag], null, null, null, platform);
+      expect(fs.existsSync).toHaveBeenCalledWith('Dockerfile');
+      expect(cp.execSync).toHaveBeenCalledWith(
+        `docker build -f Dockerfile -t ${image}:${tag} --platform linux/amd64,linux/arm64 .`,
+        cpOptions
+      );
+    });
+
     test('Build in different directory', () => {
       core.getInput.mockReturnValueOnce('Dockerfile');
       const directory = 'working-dir';


### PR DESCRIPTION
Added support for the `--platform` option as described in [docker API v1.40](https://docs.docker.com/engine/api/v1.40/#operation/ImageBuild).  Should also take care of #95.

Let me know if I've goofed up in some major way or anything / feel free to edit and/or tear apart this PR as you see fit.