### PR TITLE
Added Docker build `--platform` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ steps:
 | buildArgs      | Docker build arguments passed via `--build-arg`                                                          | No       | List    |
 | labels         | Docker build labels passed via `--label`                                                                 | No       | List    |
 | target         | Docker build target passed via `--target`                                                                | No       | String  |
+| platform       | Docker build platform passed via `--platform`                                                            | No       | String  |
 | username       | Docker registry username                                                                                 | No       | String  |
 | password       | Docker registry password or token                                                                        | No       | String  |
 | githubOrg      | GitHub organization to push image to (if not current)                                                    | No       | String  |

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
   target:
     description: "Docker build target passed via --target"
     required: false
+  platform:
+    description: "Docker build platform passed via --platform"
+    required: false
   username:
     description: "Docker registry username"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -8321,7 +8321,8 @@ const buildOpts = {
   labels: undefined,
   target: undefined,
   buildDir: undefined,
-  enableBuildKit: false
+  enableBuildKit: false,
+  platform: undefined
 };
 
 const run = () => {
@@ -8341,6 +8342,7 @@ const run = () => {
     buildOpts.target = core.getInput('target');
     buildOpts.buildDir = core.getInput('directory') || '.';
     buildOpts.enableBuildKit = core.getInput('enableBuildKit') === 'true';
+    buildOpts.platform = core.getInput('platform');
 
     // Create the Docker image name
     const imageFullName = docker.createFullImageName(registry, image, githubOwner);
@@ -8439,6 +8441,10 @@ const createBuildCommand = (imageName, dockerfile, buildOpts) => {
 
   if (buildOpts.target) {
     buildCommandPrefix = `${buildCommandPrefix} --target ${buildOpts.target}`;
+  }
+
+  if (buildOpts.platform) {
+    buildCommandPrefix = `${buildCommandPrefix} --platform ${buildOpts.platform}`;
   }
 
   if (buildOpts.enableBuildKit) {

--- a/src/docker-build-push.js
+++ b/src/docker-build-push.js
@@ -9,7 +9,8 @@ const buildOpts = {
   labels: undefined,
   target: undefined,
   buildDir: undefined,
-  enableBuildKit: false
+  enableBuildKit: false,
+  platform: undefined
 };
 
 const run = () => {
@@ -29,6 +30,7 @@ const run = () => {
     buildOpts.target = core.getInput('target');
     buildOpts.buildDir = core.getInput('directory') || '.';
     buildOpts.enableBuildKit = core.getInput('enableBuildKit') === 'true';
+    buildOpts.platform = core.getInput('platform');
 
     // Create the Docker image name
     const imageFullName = docker.createFullImageName(registry, image, githubOwner);

--- a/src/docker.js
+++ b/src/docker.js
@@ -71,6 +71,10 @@ const createBuildCommand = (imageName, dockerfile, buildOpts) => {
     buildCommandPrefix = `${buildCommandPrefix} --target ${buildOpts.target}`;
   }
 
+  if (buildOpts.platform) {
+    buildCommandPrefix = `${buildCommandPrefix} --platform ${buildOpts.platform}`;
+  }
+
   if (buildOpts.enableBuildKit) {
     buildCommandPrefix = `DOCKER_BUILDKIT=1 ${buildCommandPrefix}`;
   }

--- a/tests/docker.test.js
+++ b/tests/docker.test.js
@@ -172,7 +172,8 @@ describe('Docker build, login & push commands', () => {
         labels: undefined,
         target: undefined,
         buildDir: '.',
-        enableBuildKit: false
+        enableBuildKit: false,
+        platform: undefined
       };
       dockerfile = 'Dockerfile';
     });
@@ -220,6 +221,19 @@ describe('Docker build, login & push commands', () => {
       expect(fs.existsSync).toHaveBeenCalledWith('Dockerfile');
       expect(cp.execSync).toHaveBeenCalledWith(
         `docker build -f Dockerfile -t ${image}:${buildOpts.tags} --label version=1.0 --label maintainer=mr-smithers-excellent --target builder .`,
+        cpOptions
+      );
+    });
+
+    test('Build with platform', () => {
+      const image = 'docker.io/this-project/that-image';
+      buildOpts.tags = ['latest'];
+      buildOpts.platform = 'linux/amd64,linux/arm64';
+
+      docker.build(image, dockerfile, buildOpts);
+      expect(fs.existsSync).toHaveBeenCalledWith('Dockerfile');
+      expect(cp.execSync).toHaveBeenCalledWith(
+        `docker build -f Dockerfile -t ${image}:${buildOpts.tags} --platform linux/amd64,linux/arm64 .`,
         cpOptions
       );
     });


### PR DESCRIPTION
Added support for the `--platform` option as described in [docker API v1.40](https://docs.docker.com/engine/api/v1.40/#operation/ImageBuild).

Should also take care of Issue #95 and is a replacement for PR #99 after the codebase refactor.

Let me know if I've goofed up in some major way or anything / feel free to edit and/or tear apart this PR as you see fit.