### PR TITLE
Add optional pushImage input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: Build
         run: npm ci
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,6 +57,12 @@ jobs:
             username: GHCR_USERNAME
             password: GHCR_TOKEN
 
+          - name: Private registry
+            image: hello-world
+            dockerfile: ./e2e/multi.Dockerfile
+            registry: private-registry.io
+            skipPush: true
+
     steps:
       - name: Check out code current branch
         if: ${{ !inputs.pr-trigger }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,12 +57,6 @@ jobs:
             username: GHCR_USERNAME
             password: GHCR_TOKEN
 
-          - name: Private registry
-            image: hello-world
-            dockerfile: ./e2e/multi.Dockerfile
-            registry: private-registry.io
-            pushImage: false
-
     steps:
       - name: Check out code current branch
         if: ${{ !inputs.pr-trigger }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,7 +61,7 @@ jobs:
             image: hello-world
             dockerfile: ./e2e/multi.Dockerfile
             registry: private-registry.io
-            skipPush: true
+            pushImage: false
 
     steps:
       - name: Check out code current branch

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,8 +10,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: Build
         run: npm ci
 
-      - name: Run unit tests 
+      - name: Run unit tests
         run: npm run test

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ steps:
 | password       | Docker registry password or token                                                                        | No       | String  |
 | githubOrg      | GitHub organization to push image to (if not current)                                                    | No       | String  |
 | enableBuildKit | Enables Docker BuildKit support                                                                          | No       | Boolean |
-| pushImage      | Pushes the image to the specified registry, `true` by default                                            | No       | Boolean |
+| pushImage      | Flag for disabling the login & push steps, set to `true` by default                                      | No       | Boolean |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ steps:
 | password       | Docker registry password or token                                                                        | No       | String  |
 | githubOrg      | GitHub organization to push image to (if not current)                                                    | No       | String  |
 | enableBuildKit | Enables Docker BuildKit support                                                                          | No       | Boolean |
+| pushImage      | Pushes the image to the specified registry, `true` by default                                            | No       | Boolean |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ inputs:
     required: false
     default: "false"
   pushImage:
-    description: "Pushes the image to the specified registry"
+    description: "Flag for disabling the login & push steps, set to true by default"
     required: false
     default: "true"
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,10 @@ inputs:
     description: "Enables Docker BuildKit support"
     required: false
     default: "false"
+  pushImage:
+    description: "Pushes the image to the specified registry"
+    required: false
+    default: "true"
 outputs:
   imageFullName:
     description: "Full name of the Docker image with registry prefix and tag suffix"

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ outputs:
   tags:
     description: "Tags for the Docker image"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "anchor"

--- a/dist/index.js
+++ b/dist/index.js
@@ -10050,7 +10050,8 @@ const buildOpts = {
   target: undefined,
   buildDir: undefined,
   enableBuildKit: false,
-  platform: undefined
+  platform: undefined,
+  skipPush: false
 };
 
 const run = () => {
@@ -10071,6 +10072,7 @@ const run = () => {
     buildOpts.buildDir = core.getInput('directory') || '.';
     buildOpts.enableBuildKit = core.getInput('enableBuildKit') === 'true';
     buildOpts.platform = core.getInput('platform');
+    buildOpts.skipPush = core.getInput('pushImage') === 'false';
 
     // Create the Docker image name
     const imageFullName = docker.createFullImageName(registry, image, githubOwner);
@@ -10079,7 +10081,9 @@ const run = () => {
     // Log in, build & push the Docker image
     docker.login(username, password, registry);
     docker.build(imageFullName, dockerfile, buildOpts);
-    docker.push(imageFullName, buildOpts.tags);
+    if (!buildOpts.skipPush) {
+      docker.push(imageFullName, buildOpts.tags);
+    }
 
     // Capture outputs
     core.setOutput('imageFullName', imageFullName);

--- a/src/docker-build-push.js
+++ b/src/docker-build-push.js
@@ -39,11 +39,9 @@ const run = () => {
     core.info(`Docker image name used for this build: ${imageFullName}`);
 
     // Log in, build & push the Docker image
-    docker.login(username, password, registry);
+    docker.login(username, password, registry, buildOpts.skipPush);
     docker.build(imageFullName, dockerfile, buildOpts);
-    if (!buildOpts.skipPush) {
-      docker.push(imageFullName, buildOpts.tags);
-    }
+    docker.push(imageFullName, buildOpts.tags, buildOpts.skipPush);
 
     // Capture outputs
     core.setOutput('imageFullName', imageFullName);

--- a/src/docker-build-push.js
+++ b/src/docker-build-push.js
@@ -10,7 +10,8 @@ const buildOpts = {
   target: undefined,
   buildDir: undefined,
   enableBuildKit: false,
-  platform: undefined
+  platform: undefined,
+  skipPush: false
 };
 
 const run = () => {
@@ -31,6 +32,7 @@ const run = () => {
     buildOpts.buildDir = core.getInput('directory') || '.';
     buildOpts.enableBuildKit = core.getInput('enableBuildKit') === 'true';
     buildOpts.platform = core.getInput('platform');
+    buildOpts.skipPush = core.getInput('pushImage') === 'false';
 
     // Create the Docker image name
     const imageFullName = docker.createFullImageName(registry, image, githubOwner);
@@ -39,7 +41,9 @@ const run = () => {
     // Log in, build & push the Docker image
     docker.login(username, password, registry);
     docker.build(imageFullName, dockerfile, buildOpts);
-    docker.push(imageFullName, buildOpts.tags);
+    if (!buildOpts.skipPush) {
+      docker.push(imageFullName, buildOpts.tags);
+    }
 
     // Capture outputs
     core.setOutput('imageFullName', imageFullName);

--- a/src/docker.js
+++ b/src/docker.js
@@ -97,7 +97,12 @@ const isEcr = registry => registry && registry.includes('amazonaws');
 const getRegion = registry => registry.substring(registry.indexOf('ecr.') + 4, registry.indexOf('.amazonaws'));
 
 // Log in to provided Docker registry
-const login = (username, password, registry) => {
+const login = (username, password, registry, skipPush) => {
+  if (skipPush) {
+    core.info('Input skipPush is set to true, skipping Docker log in step...');
+    return;
+  }
+
   // If using ECR, use the AWS CLI login command in favor of docker login
   if (isEcr(registry)) {
     const region = getRegion(registry);
@@ -110,11 +115,18 @@ const login = (username, password, registry) => {
     cp.execSync(`docker login -u ${username} --password-stdin ${registry}`, {
       input: password
     });
+  } else {
+    core.setFailed('Must supply Docker registry credentials to push image!');
   }
 };
 
 // Push Docker image & all tags
-const push = (imageName, tags) => {
+const push = (imageName, tags, skipPush) => {
+  if (skipPush) {
+    core.info('Input skipPush is set to true, skipping Docker push step...');
+    return;
+  }
+
   core.info(`Pushing tags ${tags} for Docker image ${imageName}...`);
   cp.execSync(`docker push ${imageName} --all-tags`, cpOptions);
 };

--- a/tests/docker-build-push.test.js
+++ b/tests/docker-build-push.test.js
@@ -239,27 +239,6 @@ describe('Create & push Docker image to GCR', () => {
     );
   });
 
-  test('Bypass Docker push command', () => {
-    inputs.image = 'gcp-project/image';
-    inputs.registry = 'gcr.io';
-    inputs.tags = 'latest';
-    inputs.pushImage = 'false';
-    imageFullName = getDefaultImageName();
-
-    docker.createTags = jest.fn().mockReturnValueOnce(inputs.tags);
-    core.getInput = jest.fn().mockImplementation(mockGetInput(inputs));
-
-    run();
-
-    runAssertions(imageFullName, inputs);
-
-    expect(cp.execSync).toHaveBeenCalledWith(
-      `docker build -f ${inputs.dockerfile} -t ${inputs.registry}/${inputs.image}:latest .`,
-      cpOptions
-    );
-    expect(docker.push).not.toHaveBeenCalled();
-  });
-
   test('Docker login error', () => {
     const error = 'Error: Cannot perform an interactive login from a non TTY device';
     docker.login = jest.fn().mockImplementation(() => {

--- a/tests/docker.test.js
+++ b/tests/docker.test.js
@@ -296,7 +296,21 @@ describe('Docker build, login & push commands', () => {
       );
     });
 
-    test("returns undefined if empty login and doesn't execute command", () => {
+    test('Skip login command if skipPush is set to true', () => {
+      const skipPush = true;
+      docker.login(username, password, registry, skipPush);
+
+      expect(cp.execSync.mock.calls.length).toEqual(0);
+    });
+
+    test('Missing username or password should throw an error', () => {
+      docker.login(undefined, undefined, registry);
+
+      expect(cp.execSync.mock.calls.length).toEqual(0);
+      expect(core.setFailed).toHaveBeenCalled();
+    });
+
+    test('returns undefined if empty login and does not execute command', () => {
       docker.login(username, password, registry);
 
       expect(cp.execSync.mock.calls.length).toEqual(0);
@@ -311,6 +325,13 @@ describe('Docker build, login & push commands', () => {
       docker.push(imageName, tag);
 
       expect(cp.execSync).toHaveBeenCalledWith(`docker push ${imageName} --all-tags`, cpOptions);
+    });
+
+    test('Skip push command if skipPush is set to true', () => {
+      const skipPush = true;
+      docker.push('my-org/my-image', 'latest', skipPush);
+
+      expect(cp.execSync.mock.calls.length).toEqual(0);
     });
   });
 });


### PR DESCRIPTION
Adds optional `pushImage` input that is set to `true` by default. When set to `false`, the image is built but not pushed to a registry. The `docker login` step would also be bypassed when set to `false`