### PR TITLE
feat: add buildx support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,9 @@
     "node": true,
     "jest": true
   },
+  "parserOptions": {
+    "ecmaVersion": 2021
+  },
   "rules": {
     "prettier/prettier": [
       "error",

--- a/README.md
+++ b/README.md
@@ -41,24 +41,25 @@ steps:
 
 ## Inputs
 
-| Name           | Description                                                                                              | Required | Type    |
-| -------------- | -------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| image          | Docker image name                                                                                        | Yes      | String  |
-| tags           | Comma separated docker image tags (see [Tagging the image with GitOps](#tagging-the-image-using-gitops)) | No       | List    |
-| addLatest      | Adds the `latest` tag to the GitOps-generated tags                                                       | No       | Boolean |
-| addTimestamp   | Suffixes a build timestamp to the branch-based Docker tag                                                | No       | Boolean |
-| registry       | Docker registry host                                                                                     | Yes      | String  |
-| dockerfile     | Location of Dockerfile (defaults to `Dockerfile`)                                                        | No       | String  |
-| directory      | Directory to pass to `docker build` command, if not project root                                         | No       | String  |
-| buildArgs      | Docker build arguments passed via `--build-arg`                                                          | No       | List    |
-| labels         | Docker build labels passed via `--label`                                                                 | No       | List    |
-| target         | Docker build target passed via `--target`                                                                | No       | String  |
-| platform       | Docker build platform passed via `--platform`                                                            | No       | String  |
-| username       | Docker registry username                                                                                 | No       | String  |
-| password       | Docker registry password or token                                                                        | No       | String  |
-| githubOrg      | GitHub organization to push image to (if not current)                                                    | No       | String  |
-| enableBuildKit | Enables Docker BuildKit support                                                                          | No       | Boolean |
-| pushImage      | Flag for disabling the login & push steps, set to `true` by default                                      | No       | Boolean |
+| Name             | Description                                                                                              | Required | Type    |
+|------------------|----------------------------------------------------------------------------------------------------------| -------- | ------- |
+| image            | Docker image name                                                                                        | Yes      | String  |
+| tags             | Comma separated docker image tags (see [Tagging the image with GitOps](#tagging-the-image-using-gitops)) | No       | List    |
+| addLatest        | Adds the `latest` tag to the GitOps-generated tags                                                       | No       | Boolean |
+| addTimestamp     | Suffixes a build timestamp to the branch-based Docker tag                                                | No       | Boolean |
+| registry         | Docker registry host                                                                                     | Yes      | String  |
+| dockerfile       | Location of Dockerfile (defaults to `Dockerfile`)                                                        | No       | String  |
+| directory        | Directory to pass to `docker build` command, if not project root                                         | No       | String  |
+| buildArgs        | Docker build arguments passed via `--build-arg`                                                          | No       | List    |
+| labels           | Docker build labels passed via `--label`                                                                 | No       | List    |
+| target           | Docker build target passed via `--target`                                                                | No       | String  |
+| platform         | Docker build platform passed via `--platform`                                                            | No       | String  |
+| username         | Docker registry username                                                                                 | No       | String  |
+| password         | Docker registry password or token                                                                        | No       | String  |
+| githubOrg        | GitHub organization to push image to (if not current)                                                    | No       | String  |
+| enableBuildKit   | Enables Docker BuildKit support                                                                          | No       | Boolean |
+| enableMultiArch  | Enables Docker buildx support                                                                            | No       | Boolean |
+| pushImage        | Flag for disabling the login & push steps, set to `true` by default                                      | No       | Boolean |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,18 @@ If you're experiencing issues, be sure you are using the [latest stable release]
 
 ```yaml
 steps:
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v3
     name: Check out code
+
+  # Add support for more buildx platforms with QEMU (optional)
+  # https://github.com/docker/setup-qemu-action  
+  - uses: docker/setup-qemu-action@v2
+    name: Set up QEMU
+
+  # For buildx support when using enableMultiArch (optional)
+  # https://github.com/docker/setup-buildx-action  
+  - uses: docker/setup-buildx-action@v2
+    name: Set up Docker Buildx
 
   - uses: mr-smithers-excellent/docker-build-push@v5
     name: Build & push Docker image

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,9 @@ inputs:
     description: "Enables Docker BuildKit support"
     required: false
     default: "false"
+  enableMultiArch:
+    description: "Enables Docker buildx support"
+    required: false
   pushImage:
     description: "Flag for disabling the login & push steps, set to true by default"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -9472,6 +9472,7 @@ const run = () => {
     const addLatest = core.getInput('addLatest') === 'true';
     const addTimestamp = core.getInput('addTimestamp') === 'true';
     buildOpts.tags = parseArray(core.getInput('tags')) || docker.createTags(addLatest, addTimestamp);
+    buildOpts.enableMultiArch = core.getInput('enableMultiArch') === 'true';
     buildOpts.buildArgs = parseArray(core.getInput('buildArgs'));
     buildOpts.labels = parseArray(core.getInput('labels'));
     buildOpts.target = core.getInput('target');
@@ -9563,7 +9564,9 @@ const createTags = (addLatest, addTimestamp) => {
 // Dynamically create 'docker build' command based on inputs provided
 const createBuildCommand = (imageName, dockerfile, buildOpts) => {
   const tagsSuffix = buildOpts.tags.map(tag => `-t ${imageName}:${tag}`).join(' ');
-  let buildCommandPrefix = `docker build -f ${dockerfile} ${tagsSuffix}`;
+  const builder = buildOpts.enableMultiArch ? 'buildx build' : 'build';
+
+  let buildCommandPrefix = `docker ${builder} -f ${dockerfile} ${tagsSuffix}`;
 
   if (buildOpts.buildArgs) {
     const argsSuffix = buildOpts.buildArgs.map(arg => `--build-arg ${arg}`).join(' ');
@@ -9586,6 +9589,7 @@ const createBuildCommand = (imageName, dockerfile, buildOpts) => {
   if (buildOpts.enableBuildKit) {
     buildCommandPrefix = `DOCKER_BUILDKIT=1 ${buildCommandPrefix}`;
   }
+  core.info(`Calling ${buildCommandPrefix} ${buildOpts.buildDir}`);
 
   return `${buildCommandPrefix} ${buildOpts.buildDir}`;
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -9488,7 +9488,7 @@ const run = () => {
     // Log in, build & push the Docker image
     docker.login(username, password, registry, buildOpts.skipPush);
     docker.build(imageFullName, dockerfile, buildOpts);
-    docker.push(imageFullName, buildOpts.tags, buildOpts.skipPush);
+    docker.push(imageFullName, buildOpts.tags, buildOpts);
 
     // Capture outputs
     core.setOutput('imageFullName', imageFullName);
@@ -9586,10 +9586,14 @@ const createBuildCommand = (imageName, dockerfile, buildOpts) => {
     buildCommandPrefix = `${buildCommandPrefix} --platform ${buildOpts.platform}`;
   }
 
+  if (buildOpts.enableMultiArch && buildOpts.skipPush !== true) {
+    buildCommandPrefix = `${buildCommandPrefix} --push`;
+  }
+
   if (buildOpts.enableBuildKit) {
     buildCommandPrefix = `DOCKER_BUILDKIT=1 ${buildCommandPrefix}`;
   }
-  core.info(`Calling ${buildCommandPrefix} ${buildOpts.buildDir}`);
+  core.info(`BuildCommand ${buildCommandPrefix} ${buildOpts.buildDir}`);
 
   return `${buildCommandPrefix} ${buildOpts.buildDir}`;
 };
@@ -9633,8 +9637,12 @@ const login = (username, password, registry, skipPush) => {
 };
 
 // Push Docker image & all tags
-const push = (imageName, tags, skipPush) => {
-  if (skipPush) {
+const push = (imageName, tags, buildOpts) => {
+  if (buildOpts?.enableMultiArch) {
+    core.info('Input enableMultiArch is set to true, skipping Docker push step...');
+    return;
+  }
+  if (buildOpts?.skipPush) {
     core.info('Input skipPush is set to true, skipping Docker push step...');
     return;
   }

--- a/src/docker-build-push.js
+++ b/src/docker-build-push.js
@@ -26,6 +26,7 @@ const run = () => {
     const addLatest = core.getInput('addLatest') === 'true';
     const addTimestamp = core.getInput('addTimestamp') === 'true';
     buildOpts.tags = parseArray(core.getInput('tags')) || docker.createTags(addLatest, addTimestamp);
+    buildOpts.enableMultiArch = core.getInput('enableMultiArch') === 'true';
     buildOpts.buildArgs = parseArray(core.getInput('buildArgs'));
     buildOpts.labels = parseArray(core.getInput('labels'));
     buildOpts.target = core.getInput('target');

--- a/src/docker-build-push.js
+++ b/src/docker-build-push.js
@@ -42,7 +42,7 @@ const run = () => {
     // Log in, build & push the Docker image
     docker.login(username, password, registry, buildOpts.skipPush);
     docker.build(imageFullName, dockerfile, buildOpts);
-    docker.push(imageFullName, buildOpts.tags, buildOpts.skipPush);
+    docker.push(imageFullName, buildOpts.tags, buildOpts);
 
     // Capture outputs
     core.setOutput('imageFullName', imageFullName);

--- a/src/docker.js
+++ b/src/docker.js
@@ -55,7 +55,9 @@ const createTags = (addLatest, addTimestamp) => {
 // Dynamically create 'docker build' command based on inputs provided
 const createBuildCommand = (imageName, dockerfile, buildOpts) => {
   const tagsSuffix = buildOpts.tags.map(tag => `-t ${imageName}:${tag}`).join(' ');
-  let buildCommandPrefix = `docker build -f ${dockerfile} ${tagsSuffix}`;
+  const builder = buildOpts.enableMultiArch ? 'buildx build' : 'build';
+
+  let buildCommandPrefix = `docker ${builder} -f ${dockerfile} ${tagsSuffix}`;
 
   if (buildOpts.buildArgs) {
     const argsSuffix = buildOpts.buildArgs.map(arg => `--build-arg ${arg}`).join(' ');
@@ -78,6 +80,7 @@ const createBuildCommand = (imageName, dockerfile, buildOpts) => {
   if (buildOpts.enableBuildKit) {
     buildCommandPrefix = `DOCKER_BUILDKIT=1 ${buildCommandPrefix}`;
   }
+  core.info(`BuildCommand ${buildCommandPrefix} ${buildOpts.buildDir}`);
 
   return `${buildCommandPrefix} ${buildOpts.buildDir}`;
 };

--- a/src/docker.js
+++ b/src/docker.js
@@ -77,6 +77,10 @@ const createBuildCommand = (imageName, dockerfile, buildOpts) => {
     buildCommandPrefix = `${buildCommandPrefix} --platform ${buildOpts.platform}`;
   }
 
+  if (buildOpts.enableMultiArch && buildOpts.skipPush !== true) {
+    buildCommandPrefix = `${buildCommandPrefix} --push`;
+  }
+
   if (buildOpts.enableBuildKit) {
     buildCommandPrefix = `DOCKER_BUILDKIT=1 ${buildCommandPrefix}`;
   }
@@ -124,8 +128,12 @@ const login = (username, password, registry, skipPush) => {
 };
 
 // Push Docker image & all tags
-const push = (imageName, tags, skipPush) => {
-  if (skipPush) {
+const push = (imageName, tags, buildOpts) => {
+  if (buildOpts?.enableMultiArch) {
+    core.info('Input enableMultiArch is set to true, skipping Docker push step...');
+    return;
+  }
+  if (buildOpts?.skipPush) {
     core.info('Input skipPush is set to true, skipping Docker push step...');
     return;
   }

--- a/tests/docker-build-push.test.js
+++ b/tests/docker-build-push.test.js
@@ -24,7 +24,7 @@ const mockRepoName = 'some-repo';
 
 const runAssertions = (imageFullName, inputs, tagOverrides) => {
   // Inputs
-  expect(core.getInput).toHaveBeenCalledTimes(16);
+  expect(core.getInput).toHaveBeenCalledTimes(17);
 
   // Outputs
   const tags = tagOverrides || parseArray(inputs.tags);
@@ -235,6 +235,27 @@ describe('Create & push Docker image to GCR', () => {
 
     expect(cp.execSync).toHaveBeenCalledWith(
       `DOCKER_BUILDKIT=1 docker build -f ${inputs.dockerfile} -t ${inputs.registry}/${inputs.image}:latest .`,
+      cpOptions
+    );
+  });
+
+  test('Enable multiarch', () => {
+    inputs.image = 'gcp-project/image';
+    inputs.registry = 'gcr.io';
+    inputs.tags = 'latest';
+    inputs.enableBuildKit = 'true';
+    inputs.enableMultiArch = 'true';
+    imageFullName = getDefaultImageName();
+
+    docker.createTags = jest.fn().mockReturnValueOnce(inputs.tags);
+    core.getInput = jest.fn().mockImplementation(mockGetInput(inputs));
+
+    run();
+
+    runAssertions(imageFullName, inputs);
+
+    expect(cp.execSync).toHaveBeenCalledWith(
+      `DOCKER_BUILDKIT=1 docker buildx build -f ${inputs.dockerfile} -t ${inputs.registry}/${inputs.image}:latest .`,
       cpOptions
     );
   });

--- a/tests/docker-build-push.test.js
+++ b/tests/docker-build-push.test.js
@@ -255,6 +255,28 @@ describe('Create & push Docker image to GCR', () => {
     runAssertions(imageFullName, inputs);
 
     expect(cp.execSync).toHaveBeenCalledWith(
+      `DOCKER_BUILDKIT=1 docker buildx build -f ${inputs.dockerfile} -t ${inputs.registry}/${inputs.image}:latest --push .`,
+      cpOptions
+    );
+  });
+
+  test('Enable multiarch skip push', () => {
+    inputs.image = 'gcp-project/image';
+    inputs.registry = 'gcr.io';
+    inputs.tags = 'latest';
+    inputs.enableBuildKit = 'true';
+    inputs.enableMultiArch = 'true';
+    inputs.pushImage = 'false';
+    imageFullName = getDefaultImageName();
+
+    docker.createTags = jest.fn().mockReturnValueOnce(inputs.tags);
+    core.getInput = jest.fn().mockImplementation(mockGetInput(inputs));
+
+    run();
+
+    runAssertions(imageFullName, inputs);
+    expect(cp.execSync).toHaveBeenCalledTimes(1);
+    expect(cp.execSync).toHaveBeenCalledWith(
       `DOCKER_BUILDKIT=1 docker buildx build -f ${inputs.dockerfile} -t ${inputs.registry}/${inputs.image}:latest .`,
       cpOptions
     );

--- a/tests/docker.test.js
+++ b/tests/docker.test.js
@@ -328,8 +328,19 @@ describe('Docker build, login & push commands', () => {
     });
 
     test('Skip push command if skipPush is set to true', () => {
-      const skipPush = true;
-      docker.push('my-org/my-image', 'latest', skipPush);
+      const buildOpts = {
+        skipPush: true
+      };
+      docker.push('my-org/my-image', 'latest', buildOpts);
+
+      expect(cp.execSync.mock.calls.length).toEqual(0);
+    });
+
+    test('Skip push command if enableMultiArch is set to true', () => {
+      const buildOpts = {
+        enableMultiArch: true
+      };
+      docker.push('my-org/my-image', 'latest', buildOpts);
 
       expect(cp.execSync.mock.calls.length).toEqual(0);
     });


### PR DESCRIPTION
Love this action! One thing we've bumped into is the inability to build multi arch images with `buildx` as described here https://docs.docker.com/build/building/multi-platform/. I see that `platform` support was added recently, `buildx` would take it a step further.

Let me know your thoughts on this, would really help us out being able to use single action rather then start duplicating code everywhere.