### PR TITLE
Add option to use ssh-agent forwarding

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,9 @@ inputs:
   platform:
     description: "Docker build platform passed via --platform"
     required: false
+  ssh:
+    description: "Docker build ssh options passed via --ssh"
+    required: false
   username:
     description: "Docker registry username"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -9458,7 +9458,8 @@ const buildOpts = {
   overrideDriver: false,
   enableBuildKit: false,
   platform: undefined,
-  skipPush: false
+  skipPush: false,
+  ssh: undefined
 };
 
 const setBuildOpts = (addLatest, addTimestamp) => {
@@ -9472,6 +9473,7 @@ const setBuildOpts = (addLatest, addTimestamp) => {
   buildOpts.enableBuildKit = core.getInput('enableBuildKit') === 'true';
   buildOpts.platform = core.getInput('platform');
   buildOpts.skipPush = core.getInput('pushImage') === 'false';
+  buildOpts.ssh = parseArray(core.getInput('ssh'));
 };
 
 const run = () => {
@@ -9596,6 +9598,11 @@ const createBuildCommand = (imageName, dockerfile, buildOpts) => {
 
   if (buildOpts.multiPlatform && !buildOpts.skipPush) {
     buildCommandPrefix = `${buildCommandPrefix} --push`;
+  }
+
+  if (buildOpts.ssh) {
+    const sshSuffix = buildOpts.ssh.map(ssh => `--ssh ${ssh}`).join(' ');
+    buildCommandPrefix = `${buildCommandPrefix} ${sshSuffix}`;
   }
 
   if (buildOpts.enableBuildKit) {

--- a/src/docker-build-push.js
+++ b/src/docker-build-push.js
@@ -13,7 +13,8 @@ const buildOpts = {
   overrideDriver: false,
   enableBuildKit: false,
   platform: undefined,
-  skipPush: false
+  skipPush: false,
+  ssh: undefined
 };
 
 const setBuildOpts = (addLatest, addTimestamp) => {
@@ -27,6 +28,7 @@ const setBuildOpts = (addLatest, addTimestamp) => {
   buildOpts.enableBuildKit = core.getInput('enableBuildKit') === 'true';
   buildOpts.platform = core.getInput('platform');
   buildOpts.skipPush = core.getInput('pushImage') === 'false';
+  buildOpts.ssh = parseArray(core.getInput('ssh'));
 };
 
 const run = () => {

--- a/src/docker.js
+++ b/src/docker.js
@@ -83,6 +83,11 @@ const createBuildCommand = (imageName, dockerfile, buildOpts) => {
     buildCommandPrefix = `${buildCommandPrefix} --push`;
   }
 
+  if (buildOpts.ssh) {
+    const sshSuffix = buildOpts.ssh.map(ssh => `--ssh ${ssh}`).join(' ');
+    buildCommandPrefix = `${buildCommandPrefix} ${sshSuffix}`;
+  }
+
   if (buildOpts.enableBuildKit) {
     buildCommandPrefix = `DOCKER_BUILDKIT=1 ${buildCommandPrefix}`;
   }

--- a/tests/docker-build-push.test.js
+++ b/tests/docker-build-push.test.js
@@ -24,7 +24,7 @@ const mockRepoName = 'some-repo';
 
 const runAssertions = (imageFullName, inputs, tagOverrides) => {
   // Inputs
-  expect(core.getInput).toHaveBeenCalledTimes(18);
+  expect(core.getInput).toHaveBeenCalledTimes(19);
 
   // Outputs
   const tags = tagOverrides || parseArray(inputs.tags);


### PR DESCRIPTION
This exposes the ssh option of `docker build`, allowing us to load an ssh key into the ssh-agent so it can be used while building the image, e.g. to pull from a private git repository.

An example:
```yaml
steps:
  - uses: actions/checkout@v3
    name: Check out code

  - uses: webfactory/ssh-agent@v0.7.0
    with:
      ssh-private-key: ${{ secrets.SSH_KEY }}

  - uses: mr-smithers-excellent/docker-build-push@v6
    name: Build & push Docker image
    with:
      image: repo/image
      tags: v1, latest
      registry: registry-url.io
      dockerfile: Dockerfile.ci
      username: ${{ secrets.DOCKER_USERNAME }}
      password: ${{ secrets.DOCKER_PASSWORD }}
      ssh: |
        default=${{ env.SSH_AUTH_SOCK }}
```