### PR TITLE
chore: update node to v20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Build
         run: npm ci
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Build
         run: npm ci

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Build
         run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ outputs:
   tags:
     description: "Tags for the Docker image"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 branding:
   icon: "anchor"


### PR DESCRIPTION
Node.js 20 went LTS a while back now and we're seeing deprecation warnings. 
```
Node.js 16 actions are deprecated. 
Please update the following actions to use Node.js 20: mr-smithers-excellent/docker-build-push@v6. 
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

We've already upgraded our actions so I thought I'd PR this one too. It will also resolve https://github.com/mr-smithers-excellent/docker-build-push/issues/215