### PR TITLE
Fix #373

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31406,7 +31406,15 @@ const run = () => {
     core.info(`Docker image name used for this build: ${imageFullName}`);
 
     // Log in, build & push the Docker image
-    docker.login(username, password, registry);
+    /* #373: https://github.com/mr-smithers-excellent/docker-build-push/issues/373 */
+    if (buildOpts.skipPush && username === '') {
+      core.warning(
+        'Skipping docker authentication as no credentials were provided. If your base image is located on a private docker registry, the docker build might fail.'
+      );
+    } else {
+      core.info('Perform docker login with provided credentials, even if pushImage is set to false.');
+      docker.login(username, password, registry);
+    }
     docker.build(imageFullName, dockerfile, buildOpts);
     docker.push(imageFullName, buildOpts.tags, buildOpts);
 

--- a/src/docker-build-push.js
+++ b/src/docker-build-push.js
@@ -67,7 +67,9 @@ const run = () => {
     // Log in, build & push the Docker image
     /* #373: https://github.com/mr-smithers-excellent/docker-build-push/issues/373 */
     if (buildOpts.skipPush && username === '') {
-      core.warning('Skipping docker authentication as no credentials were provided. If your base image is located on a private docker registry, the docker build might fail.');
+      core.warning(
+        'Skipping docker authentication as no credentials were provided. If your base image is located on a private docker registry, the docker build might fail.'
+      );
     } else {
       core.info('Perform docker login with provided credentials, even if pushImage is set to false.');
       docker.login(username, password, registry);

--- a/src/docker-build-push.js
+++ b/src/docker-build-push.js
@@ -65,7 +65,13 @@ const run = () => {
     core.info(`Docker image name used for this build: ${imageFullName}`);
 
     // Log in, build & push the Docker image
-    docker.login(username, password, registry);
+    /* #373: https://github.com/mr-smithers-excellent/docker-build-push/issues/373 */
+    if (buildOpts.skipPush && username === '') {
+      core.warning('Skipping docker authentication as no credentials were provided. If your base image is located on a private docker registry, the docker build might fail.');
+    } else {
+      core.info('Perform docker login with provided credentials, even if pushImage is set to false.');
+      docker.login(username, password, registry);
+    }
     docker.build(imageFullName, dockerfile, buildOpts);
     docker.push(imageFullName, buildOpts.tags, buildOpts);
 


### PR DESCRIPTION
This PR is to better handle Docker login:
- If `pushImage` is `false` and no Docker registry credentials provided: skip docker authentication.
- If `pushImage` is `true` or Docker registry credentials provided: perform docker authentication, even if `pushImage=false` so that base images from private registries can be pulled.