### PR TITLE
feat: add cacheFrom and cacheTo inputs for Docker layer caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ steps:
 | labels         | Docker build labels passed via `--label`                                                                 | No       | List    |
 | target         | Docker build target passed via `--target`                                                                | No       | String  |
 | platform       | Docker build platform passed via `--platform`                                                            | No       | String  |
+| cacheFrom      | Docker cache source passed via `--cache-from` (e.g. `type=gha` or `type=registry,ref=myimage:cache`)    | No       | String  |
+| cacheTo        | Docker cache destination passed via `--cache-to` (e.g. `type=gha,mode=max`)                              | No       | String  |
 | username       | Docker registry username                                                                                 | No       | String  |
 | password       | Docker registry password or token                                                                        | No       | String  |
 | githubOrg      | GitHub organization to push image to (if not current)                                                    | No       | String  |

--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ steps:
 | labels         | Docker build labels passed via `--label`                                                                 | No       | List    |
 | target         | Docker build target passed via `--target`                                                                | No       | String  |
 | platform       | Docker build platform passed via `--platform`                                                            | No       | String  |
-| cacheFrom      | Docker cache source passed via `--cache-from` (e.g. `type=gha` or `type=registry,ref=myimage:cache`)    | No       | String  |
-| cacheTo        | Docker cache destination passed via `--cache-to` (e.g. `type=gha,mode=max`)                              | No       | String  |
 | username       | Docker registry username                                                                                 | No       | String  |
 | password       | Docker registry password or token                                                                        | No       | String  |
 | githubOrg      | GitHub organization to push image to (if not current)                                                    | No       | String  |
 | enableBuildKit | Enables Docker BuildKit support                                                                          | No       | Boolean |
+| cacheFrom      | Docker cache source passed via `--cache-from` (e.g. `type=gha` or `type=registry,ref=myimage:cache`). Requires `enableBuildKit: true` for advanced cache types.    | No       | String  |
+| cacheTo        | Docker cache destination passed via `--cache-to` (e.g. `type=gha,mode=max`). Requires `enableBuildKit: true`.                              | No       | String  |
 | multiPlatform  | Enables Docker buildx support                                                                            | No       | Boolean |
 | overrideDriver | Disables setting up docker-container driver (if `true`, alternative docker driver must be set up)        | No       | Boolean |
 | pushImage      | Flag for disabling the push step, set to `true` by default                                               | No       | Boolean |
@@ -212,6 +212,8 @@ For a `main` branch build with commit `1234567`, this would produce tags: `main-
 ## BuildKit support
 
 Enables [Docker BuildKit](https://docs.docker.com/build/buildkit/)
+
+> **Note:** BuildKit is required when using advanced cache types such as `type=gha` or `type=registry` with the `cacheFrom` and `cacheTo` inputs. Set `enableBuildKit: true` to avoid errors like `unknown flag: --cache-to`.
 
 ```yaml
 steps:

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,12 @@ inputs:
     description: "Enables Docker BuildKit support"
     required: false
     default: "false"
+  cacheFrom:
+    description: "Docker cache source passed via --cache-from (e.g. type=gha or type=registry,ref=myimage:cache)"
+    required: false
+  cacheTo:
+    description: "Docker cache destination passed via --cache-to (e.g. type=gha,mode=max)"
+    required: false
   multiPlatform:
     description: "Builds image with buildx to support multiple platforms"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -31386,6 +31386,8 @@ const setBuildOpts = (addLatest, addTimestamp) => {
   buildOpts.platform = core.getInput('platform');
   buildOpts.skipPush = core.getInput('pushImage') === 'false';
   buildOpts.ssh = parseArray(core.getInput('ssh'));
+  buildOpts.cacheFrom = core.getInput('cacheFrom');
+  buildOpts.cacheTo = core.getInput('cacheTo');
 };
 
 const run = () => {
@@ -31523,6 +31525,14 @@ const createBuildCommand = (imageName, dockerfile, buildOpts) => {
   if (buildOpts.ssh) {
     const sshSuffix = buildOpts.ssh.map(ssh => `--ssh ${ssh}`).join(' ');
     buildCommandPrefix = `${buildCommandPrefix} ${sshSuffix}`;
+  }
+
+  if (buildOpts.cacheFrom) {
+    buildCommandPrefix = `${buildCommandPrefix} --cache-from ${buildOpts.cacheFrom}`;
+  }
+
+  if (buildOpts.cacheTo) {
+    buildCommandPrefix = `${buildCommandPrefix} --cache-to ${buildOpts.cacheTo}`;
   }
 
   if (buildOpts.enableBuildKit) {

--- a/src/docker-build-push.js
+++ b/src/docker-build-push.js
@@ -45,6 +45,8 @@ const setBuildOpts = (addLatest, addTimestamp) => {
   buildOpts.platform = core.getInput('platform');
   buildOpts.skipPush = core.getInput('pushImage') === 'false';
   buildOpts.ssh = parseArray(core.getInput('ssh'));
+  buildOpts.cacheFrom = core.getInput('cacheFrom');
+  buildOpts.cacheTo = core.getInput('cacheTo');
 };
 
 const run = () => {

--- a/src/docker.js
+++ b/src/docker.js
@@ -88,6 +88,14 @@ const createBuildCommand = (imageName, dockerfile, buildOpts) => {
     buildCommandPrefix = `${buildCommandPrefix} ${sshSuffix}`;
   }
 
+  if (buildOpts.cacheFrom) {
+    buildCommandPrefix = `${buildCommandPrefix} --cache-from ${buildOpts.cacheFrom}`;
+  }
+
+  if (buildOpts.cacheTo) {
+    buildCommandPrefix = `${buildCommandPrefix} --cache-to ${buildOpts.cacheTo}`;
+  }
+
   if (buildOpts.enableBuildKit) {
     buildCommandPrefix = `DOCKER_BUILDKIT=1 ${buildCommandPrefix}`;
   }

--- a/tests/docker-build-push.test.js
+++ b/tests/docker-build-push.test.js
@@ -24,7 +24,7 @@ const mockRepoName = 'some-repo';
 
 const runAssertions = (imageFullName, inputs, tagOverrides) => {
   // Inputs
-  expect(core.getInput).toHaveBeenCalledTimes(20);
+  expect(core.getInput).toHaveBeenCalledTimes(22);
 
   // Outputs
   const tags = tagOverrides || parseArray(inputs.tags);

--- a/tests/docker.test.js
+++ b/tests/docker.test.js
@@ -277,6 +277,46 @@ describe('Docker build, login & push commands', () => {
       );
     });
 
+    test('Build with cache from and cache to', () => {
+      const image = 'docker.io/this-project/that-image';
+      buildOpts.tags = ['latest'];
+      buildOpts.cacheFrom = 'type=gha';
+      buildOpts.cacheTo = 'type=gha,mode=max';
+
+      docker.build(image, dockerfile, buildOpts);
+      expect(fs.existsSync).toHaveBeenCalledWith('Dockerfile');
+      expect(cp.execSync).toHaveBeenCalledWith(
+        `docker build -f Dockerfile -t ${image}:${buildOpts.tags} --cache-from type=gha --cache-to type=gha,mode=max .`,
+        cpOptions
+      );
+    });
+
+    test('Build with only cache from', () => {
+      const image = 'docker.io/this-project/that-image';
+      buildOpts.tags = ['latest'];
+      buildOpts.cacheFrom = 'type=registry,ref=myimage:cache';
+
+      docker.build(image, dockerfile, buildOpts);
+      expect(fs.existsSync).toHaveBeenCalledWith('Dockerfile');
+      expect(cp.execSync).toHaveBeenCalledWith(
+        `docker build -f Dockerfile -t ${image}:${buildOpts.tags} --cache-from type=registry,ref=myimage:cache .`,
+        cpOptions
+      );
+    });
+
+    test('Build with only cache to', () => {
+      const image = 'docker.io/this-project/that-image';
+      buildOpts.tags = ['latest'];
+      buildOpts.cacheTo = 'type=gha,mode=max';
+
+      docker.build(image, dockerfile, buildOpts);
+      expect(fs.existsSync).toHaveBeenCalledWith('Dockerfile');
+      expect(cp.execSync).toHaveBeenCalledWith(
+        `docker build -f Dockerfile -t ${image}:${buildOpts.tags} --cache-to type=gha,mode=max .`,
+        cpOptions
+      );
+    });
+
     test('Build in different directory', () => {
       const image = 'gcr.io/some-project/image';
       buildOpts.tags = ['v1'];


### PR DESCRIPTION
## Summary

Adds two new optional inputs — `cacheFrom` and `cacheTo` — that map directly to Docker's `--cache-from` and `--cache-to` build flags. This enables cross-run Docker layer caching when used with backends like GitHub Actions cache (`type=gha`) or registry-based cache (`type=registry`).

## Motivation

When building images in CI (e.g. GitHub Actions), Docker layers are rebuilt from scratch on every run since BuildKit's default cache doesn't persist across ephemeral runners. The `--cache-from` and `--cache-to` flags solve this by externalizing the cache, but the action doesn't currently expose them.

## Usage

```yaml
- uses: mr-smithers-excellent/docker-build-push@v6
  with:
    image: my-org/my-image
    registry: ghcr.io
    enableBuildKit: true
    cacheFrom: type=gha
    cacheTo: type=gha,mode=max
```