### PR TITLE
Add Azure Container Registry (ACR) e2e test and documentation

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,6 +50,13 @@ jobs:
             registry: 026181534292.dkr.ecr.us-west-2.amazonaws.com
             buildArgs: TEST=true
 
+          - name: ACR e2e
+            image: hello-world
+            dockerfile: ./e2e/Dockerfile
+            registrySecret: ACR_REGISTRY
+            username: ACR_USERNAME
+            password: ACR_PASSWORD
+
           - name: GHCR Legacy e2e
             image: docker-build-push/e2e-image
             dockerfile: ./e2e/Dockerfile
@@ -106,7 +113,7 @@ jobs:
           tags: ${{ github.run_id }}
           addLatest: ${{ matrix.addLatest }}
           addTimestamp: ${{ matrix.addTimestamp }}
-          registry: ${{ matrix.registry }}
+          registry: ${{ matrix.registrySecret && secrets[matrix.registrySecret] || matrix.registry }}
           dockerfile: ${{ matrix.dockerfile }}
           directory: ${{ matrix.directory }}
           buildArgs: ${{ matrix.buildArgs }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Builds a Docker image and pushes it to the private registry of your choosing.
 - Docker Hub
 - Google Container Registry (GCR)
 - AWS Elastic Container Registry (ECR)
+- Azure Container Registry (ACR)
 - GitHub Docker Registry
 
 ## Features
@@ -143,6 +144,25 @@ with:
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+```
+
+### Azure Container Registry (ACR)
+
+- Create an Azure Container Registry (see [quickstart](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-get-started-portal))
+- Enable the **Admin user** under your registry's **Settings → Access keys**
+- Save the following as secrets in your GitHub repo:
+  - `ACR_REGISTRY`: your login server, e.g. `yourname.azurecr.io`
+  - `ACR_USERNAME`: the admin username (same as registry name)
+  - `ACR_PASSWORD`: one of the generated passwords
+- Modify sample below and include in your workflow `.github/workflows/*.yml` file
+
+```yaml
+uses: mr-smithers-excellent/docker-build-push@v6
+with:
+  image: image-name
+  registry: ${{ secrets.ACR_REGISTRY }}
+  username: ${{ secrets.ACR_USERNAME }}
+  password: ${{ secrets.ACR_PASSWORD }}
 ```
 
 ### GitHub Container Registry


### PR DESCRIPTION
- Add ACR matrix entry to e2e.yml using ACR_REGISTRY, ACR_USERNAME, and ACR_PASSWORD GitHub secrets
- Update registry step to support secret-based registry lookup via matrix.registrySecret, falling back to matrix.registry for existing entries (Docker Hub, GAR, ECR, GHCR) which use literal values
- Add ACR to the supported registries list in README
- Add ACR example section in README with setup steps and workflow sample

https://claude.ai/code/session_01CWf8Vn7pWrCsmpdCLVpJ8K