### PR TITLE
Add Google Artifact Registry (GAR) support

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,17 +105,20 @@ jobs:
             });
             return check;
 
-      - name: Resolve registry
+      - name: Resolve registry and image
         id: resolve
         env:
           REGISTRY_SECRET: ${{ matrix.registrySecret && secrets[matrix.registrySecret] || '' }}
+          IMAGE_SECRET: ${{ matrix.imageSecret && secrets[matrix.imageSecret] || '' }}
         run: |
           REGISTRY="${REGISTRY_SECRET:-${{ matrix.registry }}}"
-          if [ -z "$REGISTRY" ]; then
+          IMAGE="${IMAGE_SECRET:-${{ matrix.image }}}"
+          if [ -z "$REGISTRY" ] || [ -z "$IMAGE" ]; then
             echo "configured=false" >> $GITHUB_OUTPUT
           else
             echo "configured=true" >> $GITHUB_OUTPUT
             echo "registry=$REGISTRY" >> $GITHUB_OUTPUT
+            echo "image=$IMAGE" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push Docker image
@@ -123,7 +126,7 @@ jobs:
         if: steps.resolve.outputs.configured == 'true'
         uses: ./
         with:
-          image: ${{ matrix.imageSecret && secrets[matrix.imageSecret] || matrix.image }}
+          image: ${{ steps.resolve.outputs.image }}
           tags: ${{ github.run_id }}
           addLatest: ${{ matrix.addLatest }}
           addTimestamp: ${{ matrix.addTimestamp }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,9 +36,9 @@ jobs:
             platform: linux/amd64,linux/arm64,linux/arm/v7
 
           - name: GAR e2e
-            image: orbital-bank-301021/hello-world/hello-world
+            imageSecret: GAR_IMAGE
             dockerfile: ./e2e/Dockerfile
-            registry: us-west1-docker.pkg.dev
+            registrySecret: GAR_REGISTRY
             username: GAR_USERNAME
             password: GAR_PASSWORD
             labels: org.opencontainers.image.description="A Hello World image used for e2e tests"
@@ -123,7 +123,7 @@ jobs:
         if: steps.resolve.outputs.configured == 'true'
         uses: ./
         with:
-          image: ${{ matrix.image }}
+          image: ${{ matrix.imageSecret && secrets[matrix.imageSecret] || matrix.image }}
           tags: ${{ github.run_id }}
           addLatest: ${{ matrix.addLatest }}
           addTimestamp: ${{ matrix.addTimestamp }}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Builds a Docker image and pushes it to the private registry of your choosing.
 
 - Docker Hub
 - Google Container Registry (GCR)
+- Google Artifact Registry (GAR)
 - AWS Elastic Container Registry (ECR)
 - Azure Container Registry (ACR)
 - GitHub Docker Registry
@@ -128,6 +129,26 @@ with:
   registry: gcr.io
   username: _json_key
   password: ${{ secrets.DOCKER_PASSWORD }}
+```
+
+### Google Artifact Registry (GAR)
+
+- Create a Docker repository in GAR (see [quickstart](https://cloud.google.com/artifact-registry/docs/docker/pushing-and-pulling))
+- Create a service account with the **Artifact Registry Writer** role (`roles/artifactregistry.writer`)
+- Create and download a JSON key for the service account (**IAM & Admin → Service Accounts → Keys → Add Key → JSON**)
+- Save the following as secrets in your GitHub repo:
+  - `GAR_REGISTRY`: your registry host, e.g. `us-west1-docker.pkg.dev`
+  - `GAR_PASSWORD`: the full contents of the downloaded JSON key file
+- Modify sample below and include in your workflow `.github/workflows/*.yml` file
+- Set the username to `_json_key` when authenticating with a JSON key
+
+```yaml
+uses: mr-smithers-excellent/docker-build-push@v6
+with:
+  image: project-id/repository/image-name
+  registry: ${{ secrets.GAR_REGISTRY }}
+  username: _json_key
+  password: ${{ secrets.GAR_PASSWORD }}
 ```
 
 ### AWS Elastic Container Registry (ECR)


### PR DESCRIPTION
- Add GAR to the supported registries list in README
- Add GAR setup instructions and workflow example to README Examples section (service account JSON key auth, _json_key username)
- Update GAR e2e matrix entry to use GAR_REGISTRY and GAR_IMAGE secrets instead of hardcoded project ID and region, consistent with ACR pattern
- Extend step template to support imageSecret for secret-based image name lookup (needed for GAR where the project ID lives in the image path)
- Update if conditions on build and verify steps to also gate on imageSecret being configured, so the job skips gracefully when GAR secrets are not present

https://claude.ai/code/session_01CWf8Vn7pWrCsmpdCLVpJ8K