### PR TITLE
Add skipLogin input to allow bypassing Docker login step

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ steps:
 | cacheTo        | Docker cache destination passed via `--cache-to` (e.g. `type=gha,mode=max`). Requires `enableBuildKit: true`.                              | No       | String  |
 | multiPlatform  | Enables Docker buildx support                                                                            | No       | Boolean |
 | overrideDriver | Disables setting up docker-container driver (if `true`, alternative docker driver must be set up)        | No       | Boolean |
+| skipLogin      | Skip the Docker login step, useful when credentials are pre-configured via a credential helper or OIDC   | No       | Boolean |
 | pushImage      | Flag for disabling the push step, set to `true` by default                                               | No       | Boolean |
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -72,6 +72,10 @@ inputs:
     description: "Disables setting up docker-container driver"
     required: false
     default: "false"
+  skipLogin:
+    description: "Skip the Docker login step, useful when credentials are pre-configured via a credential helper or OIDC"
+    required: false
+    default: "false"
   pushImage:
     description: "Flag for disabling the login & push steps, set to true by default"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -19577,10 +19577,13 @@ var run = () => {
     const githubOwner = getInput("githubOrg") || getDefaultOwner();
     const addLatest = getInput("addLatest") === "true";
     const addTimestamp = getInput("addTimestamp") === "true";
+    const skipLogin = getInput("skipLogin") === "true";
     setBuildOpts(addLatest, addTimestamp);
     const imageFullName = createFullImageName(registry, image, githubOwner);
     info(`Docker image name used for this build: ${imageFullName}`);
-    if (buildOpts.skipPush && username === "") {
+    if (skipLogin) {
+      info("Skipping Docker login as skipLogin is set to true.");
+    } else if (buildOpts.skipPush && username === "") {
       warning(
         "Skipping docker authentication as no credentials were provided. If your base image is located on a private docker registry, the docker build might fail."
       );

--- a/src/docker-build-push.js
+++ b/src/docker-build-push.js
@@ -60,6 +60,7 @@ const run = () => {
     const githubOwner = core.getInput('githubOrg') || github.getDefaultOwner();
     const addLatest = core.getInput('addLatest') === 'true';
     const addTimestamp = core.getInput('addTimestamp') === 'true';
+    const skipLogin = core.getInput('skipLogin') === 'true';
     setBuildOpts(addLatest, addTimestamp);
 
     // Create the Docker image name
@@ -67,8 +68,11 @@ const run = () => {
     core.info(`Docker image name used for this build: ${imageFullName}`);
 
     // Log in, build & push the Docker image
-    /* #373: https://github.com/mr-smithers-excellent/docker-build-push/issues/373 */
-    if (buildOpts.skipPush && username === '') {
+    /* #224: https://github.com/mr-smithers-excellent/docker-build-push/issues/224 */
+    if (skipLogin) {
+      core.info('Skipping Docker login as skipLogin is set to true.');
+      /* #373: https://github.com/mr-smithers-excellent/docker-build-push/issues/373 */
+    } else if (buildOpts.skipPush && username === '') {
       core.warning(
         'Skipping docker authentication as no credentials were provided. If your base image is located on a private docker registry, the docker build might fail.'
       );

--- a/tests/docker-build-push.test.js
+++ b/tests/docker-build-push.test.js
@@ -27,7 +27,7 @@ const mockRepoName = 'some-repo';
 const GITHUB_REGISTRY_URLS = ['docker.pkg.github.com', 'ghcr.io'];
 
 const runAssertions = (imageFullName, inputs, tagOverrides) => {
-  expect(core.getInput).toHaveBeenCalledTimes(22);
+  expect(core.getInput).toHaveBeenCalledTimes(23);
 
   const tags = tagOverrides || parseArray(inputs.tags);
   expect(core.setOutput).toHaveBeenCalledTimes(3);
@@ -71,7 +71,8 @@ beforeEach(() => {
     dockerfile: 'Dockerfile',
     buildDir: '.',
     enableBuildKit: undefined,
-    platform: undefined
+    platform: undefined,
+    skipLogin: undefined
   };
   imageFullName = undefined;
 });
@@ -279,6 +280,39 @@ describe('Create & push Docker image to GCR', () => {
       inputs.dockerfile,
       expect.objectContaining({ multiPlatform: true, skipPush: true })
     );
+  });
+
+  test('Skip login when skipLogin is true', () => {
+    inputs.image = 'gcp-project/image';
+    inputs.registry = 'gcr.io';
+    inputs.tags = 'latest';
+    inputs.skipLogin = 'true';
+    imageFullName = getDefaultImageName();
+
+    core.getInput.mockImplementation(mockGetInput(inputs));
+
+    run();
+
+    runAssertions(imageFullName, inputs);
+    expect(docker.login).not.toHaveBeenCalled();
+    expect(docker.build).toHaveBeenCalledWith(imageFullName, inputs.dockerfile, expect.any(Object));
+  });
+
+  test('Skip login warning when pushImage is false and no credentials provided', () => {
+    inputs.image = 'gcp-project/image';
+    inputs.registry = 'gcr.io';
+    inputs.tags = 'latest';
+    inputs.pushImage = 'false';
+    inputs.username = '';
+    imageFullName = getDefaultImageName();
+
+    core.getInput.mockImplementation(mockGetInput(inputs));
+
+    run();
+
+    runAssertions(imageFullName, inputs);
+    expect(docker.login).not.toHaveBeenCalled();
+    expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('Skipping docker authentication'));
   });
 
   test('Enable appendMode to combine generated and custom tags', () => {


### PR DESCRIPTION
Adds a new skipLogin boolean input (default false) that lets users skip the Docker login step when credentials are pre-configured externally via a credential helper, OIDC token exchange, or unauthenticated registries.

Closes #224

https://claude.ai/code/session_01CWf8Vn7pWrCsmpdCLVpJ8K