### PR TITLE
Add secrets input for Docker build secrets (--secret flag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ steps:
 | labels         | Docker build labels passed via `--label`                                                                 | No       | List    |
 | target         | Docker build target passed via `--target`                                                                | No       | String  |
 | platform       | Docker build platform passed via `--platform`                                                            | No       | String  |
+| secrets        | Docker build secrets passed via `--secret` (e.g. `id=mysecret,src=secret.txt`). Requires BuildKit.      | No       | List    |
 | username       | Docker registry username                                                                                 | No       | String  |
 | password       | Docker registry password or token                                                                        | No       | String  |
 | githubOrg      | GitHub organization to push image to (if not current)                                                    | No       | String  |

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
   ssh:
     description: "Docker build ssh options passed via --ssh"
     required: false
+  secrets:
+    description: "Docker build secrets passed via --secret (e.g. id=mysecret,src=secret.txt). Requires BuildKit."
+    required: false
   username:
     description: "Docker registry username"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -19470,6 +19470,10 @@ var createBuildCommand = (imageName, dockerfile, buildOpts2) => {
     const sshSuffix = buildOpts2.ssh.map((ssh) => `--ssh ${ssh}`).join(" ");
     buildCommandPrefix = `${buildCommandPrefix} ${sshSuffix}`;
   }
+  if (buildOpts2.secrets) {
+    const secretsSuffix = buildOpts2.secrets.map((secret) => `--secret ${secret}`).join(" ");
+    buildCommandPrefix = `${buildCommandPrefix} ${secretsSuffix}`;
+  }
   if (buildOpts2.cacheFrom) {
     buildCommandPrefix = `${buildCommandPrefix} --cache-from ${buildOpts2.cacheFrom}`;
   }
@@ -19564,6 +19568,7 @@ var setBuildOpts = (addLatest, addTimestamp) => {
   buildOpts.platform = getInput("platform");
   buildOpts.skipPush = getInput("pushImage") === "false";
   buildOpts.ssh = parseArray(getInput("ssh"));
+  buildOpts.secrets = parseArray(getInput("secrets"));
   buildOpts.cacheFrom = getInput("cacheFrom");
   buildOpts.cacheTo = getInput("cacheTo");
 };

--- a/src/docker-build-push.js
+++ b/src/docker-build-push.js
@@ -45,6 +45,7 @@ const setBuildOpts = (addLatest, addTimestamp) => {
   buildOpts.platform = core.getInput('platform');
   buildOpts.skipPush = core.getInput('pushImage') === 'false';
   buildOpts.ssh = parseArray(core.getInput('ssh'));
+  buildOpts.secrets = parseArray(core.getInput('secrets'));
   buildOpts.cacheFrom = core.getInput('cacheFrom');
   buildOpts.cacheTo = core.getInput('cacheTo');
 };

--- a/src/docker.js
+++ b/src/docker.js
@@ -87,6 +87,11 @@ const createBuildCommand = (imageName, dockerfile, buildOpts) => {
     buildCommandPrefix = `${buildCommandPrefix} ${sshSuffix}`;
   }
 
+  if (buildOpts.secrets) {
+    const secretsSuffix = buildOpts.secrets.map(secret => `--secret ${secret}`).join(' ');
+    buildCommandPrefix = `${buildCommandPrefix} ${secretsSuffix}`;
+  }
+
   if (buildOpts.cacheFrom) {
     buildCommandPrefix = `${buildCommandPrefix} --cache-from ${buildOpts.cacheFrom}`;
   }

--- a/tests/docker-build-push.test.js
+++ b/tests/docker-build-push.test.js
@@ -27,7 +27,7 @@ const mockRepoName = 'some-repo';
 const GITHUB_REGISTRY_URLS = ['docker.pkg.github.com', 'ghcr.io'];
 
 const runAssertions = (imageFullName, inputs, tagOverrides) => {
-  expect(core.getInput).toHaveBeenCalledTimes(23);
+  expect(core.getInput).toHaveBeenCalledTimes(24);
 
   const tags = tagOverrides || parseArray(inputs.tags);
   expect(core.setOutput).toHaveBeenCalledTimes(3);
@@ -72,7 +72,8 @@ beforeEach(() => {
     buildDir: '.',
     enableBuildKit: undefined,
     platform: undefined,
-    skipLogin: undefined
+    skipLogin: undefined,
+    secrets: undefined
   };
   imageFullName = undefined;
 });
@@ -201,6 +202,27 @@ describe('Create & push Docker image to GCR', () => {
       expect.objectContaining({
         buildArgs: ['VERSION=1.1.1', 'BUILD_DATE=2020-01-14'],
         labels: ['version=1.0', 'maintainer=mr-smithers-excellent']
+      })
+    );
+  });
+
+  test('Valid Docker inputs with build secrets', () => {
+    inputs.image = 'gcp-project/image';
+    inputs.registry = 'gcr.io';
+    inputs.tags = 'latest';
+    inputs.secrets = 'id=mysecret,src=secret.txt,id=npmtoken,env=NPM_TOKEN';
+    imageFullName = getDefaultImageName();
+
+    core.getInput.mockImplementation(mockGetInput(inputs));
+
+    run();
+
+    runAssertions(imageFullName, inputs);
+    expect(docker.build).toHaveBeenCalledWith(
+      imageFullName,
+      inputs.dockerfile,
+      expect.objectContaining({
+        secrets: ['id=mysecret', 'src=secret.txt', 'id=npmtoken', 'env=NPM_TOKEN']
       })
     );
   });


### PR DESCRIPTION
Adds a new secrets input (comma-separated list) that passes each entry as a --secret flag to docker build, enabling BuildKit secret mounts without leaking sensitive values into image layers.

Closes #378

https://claude.ai/code/session_01CWf8Vn7pWrCsmpdCLVpJ8K