### PR TITLE
Improve security and workflow triggers for dependabot and e2e tests

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -5,14 +5,15 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   unit-tests:
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     name: Unit Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out PR code
         uses: actions/checkout@v6
@@ -45,8 +46,11 @@ jobs:
 
   auto-merge:
     needs: [unit-tests]
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Enable auto-merge
         run: gh pr merge --auto --merge "${{ github.event.pull_request.html_url }}"

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -1,12 +1,13 @@
 name: Ok To Test
 
 on:
-  workflow_dispatch:
+  issue_comment:
+    types: [created]
 
 jobs:
   ok-to-test:
     runs-on: ubuntu-latest
-    if: false
+    if: ${{ github.event.issue.pull_request }}
     steps:
     - name: Generate token
       id: generate_token

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -1,13 +1,12 @@
 name: 'PR e2e Tests'
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  repository_dispatch:
+    types: [ok-to-test-command]
 
 jobs:
   e2e:
     uses: ./.github/workflows/e2e.yml
     secrets: inherit
     with:
-      pr-trigger: false
-      ref: ${{ github.event.pull_request.head.sha }}
+      pr-trigger: true


### PR DESCRIPTION
## Summary
This PR enhances the security posture and improves the workflow automation for dependency updates and end-to-end testing by implementing least-privilege permissions and safer trigger mechanisms.

## Key Changes

- **Dependabot workflow security hardening:**
  - Changed global permissions from `contents: write` and `pull-requests: write` to `contents: read` only
  - Added job-level permissions to `unit-tests` and `auto-merge` jobs with only required permissions
  - Enhanced fork protection by adding `github.event.pull_request.head.repo.full_name == github.repository` check to both jobs, preventing execution on PRs from forks

- **E2E test workflow trigger refactoring:**
  - Changed `pr-e2e.yml` from `pull_request_target` trigger to `repository_dispatch` with `ok-to-test-command` type
  - Updated to use `pr-trigger: true` instead of `pr-trigger: false`
  - Removed hardcoded `ref` parameter to use workflow defaults

- **Ok-to-test workflow implementation:**
  - Changed trigger from `workflow_dispatch` to `issue_comment` (created events only)
  - Added conditional check `if: ${{ github.event.issue.pull_request }}` to only run on PR comments
  - Enabled the workflow (changed `if: false` to conditional check)

## Implementation Details

These changes implement a safer approval workflow for external contributions:
1. E2E tests no longer run automatically on all PRs from forks (security risk)
2. Instead, they require an explicit `/ok-to-test` comment on the PR by a maintainer
3. Permissions are scoped to the minimum required at the job level rather than globally
4. Fork PRs are explicitly blocked from running dependabot workflows to prevent token exposure

https://claude.ai/code/session_01XBvhjU29FkmZUAsvoktits