### PR TITLE
Restore automatic dependabot e2e and fix e2e.yml token permissions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -44,8 +44,19 @@ jobs:
             git push origin HEAD:${{ github.event.pull_request.head.ref }}
           fi
 
+  e2e:
+    if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: ./.github/workflows/e2e.yml
+    permissions:
+      contents: read
+      packages: write
+    secrets: inherit
+    with:
+      pr-trigger: false
+      ref: ${{ github.event.pull_request.head.sha }}
+
   auto-merge:
-    needs: [unit-tests]
+    needs: [unit-tests, e2e]
     if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   e2e:
     uses: ./.github/workflows/e2e.yml
+    permissions:
+      contents: read
+      packages: write
     secrets: inherit
     with:
       pr-trigger: false

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   e2e:
     uses: ./.github/workflows/e2e.yml
+    permissions:
+      contents: read
+      checks: write
+      packages: write
     secrets: inherit
     with:
       pr-trigger: true


### PR DESCRIPTION
## Summary

Follow-up to #478. Restoring the `/·o·k-to-test` gate surfaced a real bug, and the original ask (auto-merge dependabot PRs without manual approval) needed its own fix rather than relying on `/·o·k-to-test` every time.

- **`dependabot.yml`**: restores the `e2e` job that was removed in the same regression that dropped the `/·o·k-to-test` gate (commit `36995a4`). It mirrors the pre-regression design (`pr-trigger: false`, direct checkout of the PR head SHA) and reuses the same-repo + actor gate already on `unit-tests`/`auto-merge`. `auto-merge` now requires both `unit-tests` and `e2e` to pass. This runs automatically for genuine Dependabot PRs — no manual `/·o·k-to-test` comment needed.

  This is safe against the confused-deputy bypass `dependabot.yml` was fixed for in #478: that attack requires the PR to originate from the attacker's own fork, and `github.event.pull_request.head.repo.full_name == github.repository` can never be true for a fork-originated PR — it isn't spoofable the way the actor check was, since forging it requires already having push access to this repo.

- **`pr-e2e.yml`**, the new `dependabot.yml` `e2e` job, and **`nightly-e2e.yml`**: declare explicit job-level `permissions:` (`checks: write` only where check-run creation steps run, `packages: write` everywhere, for the GHCR-legacy push step). `e2e.yml` is a reusable workflow with no permissions of its own, so it only gets what its caller grants — and the repo-wide default `GITHUB_TOKEN` is now read-only. Restoring `pr-trigger: true` in `pr-e2e.yml` exercises the check-run-creation code path for the first time since April (the old unauthorized trigger always ran with `pr-trigger: false`), which is what surfaced the missing `checks: write` scope as a real failure (`Resource not accessible by integration` on run [34055424791](https://github.com/mr-smithers-excellent/docker-build-push/actions/runs/34055424791)).

## Test plan
- [x] YAML-validated all three changed files
- [x] Confirmed the failure mode against the actual failed run's job logs (`checks.create` → `Resource not accessible by integration`)
- [ ] Confirm the next real Dependabot PR runs `e2e` automatically and auto-merges once both `unit-tests` and `e2e` pass
- [ ] Confirm `/·o·k-to-test` on a PR now completes the check-run steps successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBvhjU29FkmZUAsvoktits

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBvhjU29FkmZUAsvoktits)_