### PR TITLE
Run e2e automatically on same-repo PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,3 +26,18 @@ jobs:
           npm run build
           git add dist/
           git diff --staged --exit-code || (echo "❌ dist/ is not up-to-date. Please run 'npm run build' and commit the changes." && exit 1)
+
+  e2e:
+    # Same-repo PRs already get secrets under plain `pull_request` (GitHub only
+    # withholds secrets for fork PRs), so this can run automatically on every
+    # push without the /ok-to-test gate. Fork PRs are excluded explicitly:
+    # they'd get no secrets anyway, so the e2e steps would just fail.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: ./.github/workflows/e2e.yml
+    permissions:
+      contents: read
+      packages: write
+    secrets: inherit
+    with:
+      pr-trigger: false
+      ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary
- Adds an `e2e` job to `pr.yml` that calls `e2e.yml` directly, gated on `github.event.pull_request.head.repo.full_name == github.repository` — the same same-repo check `dependabot.yml` already uses to auto-run e2e for Dependabot PRs.
- This means e2e now runs automatically on every push to a same-repo PR branch (e.g. a maintainer's own branch), with no `/ok-to-test` comment needed.
- Fork PRs are unaffected: they never receive secrets under `pull_request` regardless of this change, so `/ok-to-test` remains the only way to run e2e against fork contributions (with a maintainer reviewing each sha before granting secret access).

## Why
`/ok-to-test` exists to gate secret access for fork PRs, since GitHub withholds secrets from `pull_request`-triggered workflows for forks. But that gate was also blocking same-repo PRs (branches pushed directly to this repo), which already get full secrets under plain `pull_request` — the fork restriction never applied to them in the first place. This was discovered while working through [#480](https://github.com/mr-smithers-excellent/docker-build-push/pull/480), a same-repo PR that stayed `BLOCKED` on required e2e checks that could only be satisfied via a manual comment.

## Security note
No new attack surface: the condition mirrors `dependabot.yml`'s existing trust boundary exactly, so this doesn't grant secrets to anything that couldn't already get them another way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
