### PR TITLE
Add SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest major version receives security updates. Users should
+always reference the action via its major version tag (e.g. `@v7`) rather
+than pinning to a minor/patch version or a commit SHA that predates a fix,
+so security patches are picked up automatically.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 7.x     | :white_check_mark: |
+| < 7.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+This repository has [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+enabled. To report a vulnerability:
+
+1. Go to the [Security tab](https://github.com/mr-smithers-excellent/docker-build-push/security) of this repository.
+2. Click **Report a vulnerability**.
+3. Fill in as much detail as you can: affected version(s), a description of
+   the issue, its impact, and steps to reproduce (a proof-of-concept is
+   appreciated).
+
+This opens a private draft security advisory visible only to you and the
+maintainers, so the issue can be discussed and fixed before public
+disclosure.
+
+You can expect an initial response within a few business days. Once a fix
+is available and released, the advisory will be published and you will be
+credited as the reporter unless you request otherwise.


### PR DESCRIPTION
## Summary

- Adds `.github/SECURITY.md` per [GitHub's guide](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/add-security-policy).
- States the supported-version policy (latest major tag only, currently `v7.x`).
- Directs reporters to the repo's already-enabled [private vulnerability reporting](https://github.com/mr-smithers-excellent/docker-build-push/security) flow instead of public issues.

## Test plan
- [x] Rendered the markdown locally to confirm formatting
- [ ] Confirm GitHub surfaces the "Security policy" link under the repo's Security tab once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBvhjU29FkmZUAsvoktits

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBvhjU29FkmZUAsvoktits)_