### PR TITLE
Exclude Dependabot from pr.yml's e2e job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,8 +31,11 @@ jobs:
     # Same-repo PRs already get secrets under plain `pull_request` (GitHub only
     # withholds secrets for fork PRs), so this can run automatically on every
     # push without the /ok-to-test gate. Fork PRs are excluded explicitly:
-    # they'd get no secrets anyway, so the e2e steps would just fail.
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    # they'd get no secrets anyway, so the e2e steps would just fail. Dependabot
+    # PRs are also excluded: GitHub withholds secrets from Dependabot-triggered
+    # pull_request events regardless of same-repo status, and dependabot.yml
+    # already runs e2e for those (with secrets, via pull_request_target).
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     uses: ./.github/workflows/e2e.yml
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Fixes a bug from [#485](https://github.com/mr-smithers-excellent/docker-build-push/pull/485): the `e2e` job added to `pr.yml` only excluded fork PRs, not Dependabot PRs. GitHub withholds secrets from Dependabot-triggered `pull_request` events even on same-repo branches (a separate, hardcoded restriction from the general fork-PR one). As a result, the job ran with empty registry credentials on every Dependabot PR and failed with `unauthorized: access token has insufficient scopes` — see [run 34216887045 on #487](https://github.com/mr-smithers-excellent/docker-build-push/actions/runs/34216887045/job/102030647280) — while `dependabot.yml`'s own `e2e` job (which does get secrets via `pull_request_target`) ran the real checks in parallel under the same check context, producing conflicting pass/fail results for the same context name.

## Fix
Add the same `github.actor != 'dependabot[bot]'` exclusion that `run-tests` already has, to the new `e2e` job's `if:` condition. Dependabot PRs keep their working e2e coverage from `dependabot.yml` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
